### PR TITLE
ignore unsupported git options

### DIFF
--- a/git-remote-gcrypt
+++ b/git-remote-gcrypt
@@ -934,5 +934,24 @@ then
 		exit 100
 	fi
 else
-	gcrypt_main_loop "$@"
+	# crappy reimplementation of getopt, because we need to ignore arbitrary arguments
+	for i
+	do
+	    case "$1" in
+	    -*)
+	        # ignore other options
+	        shift
+	        ;;
+	    *)
+	        # first argument is name, second is url
+	        if [ -n "$name" ]; then
+	            name="$1"
+		else
+		    url="$1"
+		fi
+	        shift
+	        ;;
+	    esac   
+	done
+	gcrypt_main_loop "$name" "$url"
 fi


### PR DESCRIPTION
It seems that git can send all sorts of options to the remote backends.

We don't support any, yet we should at least not crash. The example I stumbled upon is `push.sign=ifAsked` in the config, which translated into the `--sign=ifAsked` option, as in [this bug report](https://git-annex.branchable.com/bugs/gcrypt_repository_not_found/). I haven't tested if it works and the code is rather ugly, but let's take this as a proof of concept for now.

Thank you for your interest in contributing to this project!

Please **do not** submit a pull request on GitHub.  This repository is
an automated mirror, and I don't develop using GitHub's platform.

Instead, either

- publish a branch somewhere (a GitHub fork is fine), and e-mail
  <spwhitton@spwhitton.name> asking me to merge your branch, possibly
  using git-request-pull(1)

- prepare patches with git-format-patch(1), and send them to
  <spwhitton@spwhitton.name>, possibly using git-send-email(1)
